### PR TITLE
Fix compatibility issues with macOS

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -25,9 +25,9 @@ where
         Err(error::HttpError::NotFound(b"not ugo+r"))
     } else if (meta.mode() & 0o101) == 0o001 {
         Err(error::HttpError::NotFound(b"o+x but u-x"))
-    } else if (meta.mode() & libc::S_IFMT) == libc::S_IFDIR {
+    } else if meta.is_dir() {
         Ok(FileOrDir::Dir)
-    } else if (meta.mode() & libc::S_IFMT) == libc::S_IFREG {
+    } else if meta.is_file() {
         Ok(FileOrDir::File(OpenFile {
             file: f,
             mtime: meta.modified()?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ pub fn main() {
     });
     with_env_var("GID", |gid| {
         let gid = nix::unistd::Gid::from_raw(gid);
+        #[cfg(not(any(target_os = "ios", target_os = "macos")))]
         nix::unistd::setgroups(&[gid])?;
         nix::unistd::setgid(gid)
     });


### PR DESCRIPTION
mode_t in macOS's libc is u16 (and it's u32 for Linux).
Metadata's mode() returns u32 however, so on macos direct bit masking
of the mode requires casting.

Apple highly discourages the use of setgroups on macOS, and nix
doesn't wrap it there.